### PR TITLE
Fix QHeaderView import

### DIFF
--- a/gui/tabs/vendor_names.py
+++ b/gui/tabs/vendor_names.py
@@ -1,5 +1,15 @@
 # ── intake-manager/gui/tabs/vendor_names.py ──────────────────────────
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QPushButton, QTableWidget, QTableWidgetItem, QMessageBox
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QMessageBox,
+    QHeaderView,
+)
 from PyQt5.QtCore import Qt
 
 class VendorNamesTab(QWidget):


### PR DESCRIPTION
## Summary
- import `QHeaderView` in `vendor_names` tab

## Testing
- `python -m py_compile gui/tabs/vendor_names.py`

------
https://chatgpt.com/codex/tasks/task_e_68887bd3e6f08329a76ee57d931dbad6