### PR TITLE
Make DB path configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 ".env" 
+**/__pycache__/

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ This tool opens in a new window and provides three tabs:
    ```
 2. Create a `.env` file with the environment variables used in
    `secrets.py` (for example `USERNAME` and `PASSWORD`).
+3. *(Optional)* Set `INTAKE_DB_PATH` in your environment to override the
+   default location of `intake.db`.
 
-3. Run the application:
+4. Run the application:
 
    ```bash
    python main.py

--- a/data/database.py
+++ b/data/database.py
@@ -1,9 +1,14 @@
 # ── intake-manager/data/database.py ───────────────────────────────────
 import sqlite3
 import os
+from dotenv import load_dotenv
 
-DB_FOLDER = r"D:\\Scripts\\Intake 7.20.25"
-DB_PATH = os.path.join(DB_FOLDER, "intake.db")
+load_dotenv()
+
+# Allow overrides via environment variables
+DEFAULT_DB_PATH = os.path.join(os.getcwd(), "intake.db")
+DB_PATH = os.getenv("INTAKE_DB_PATH", DEFAULT_DB_PATH)
+DB_FOLDER = os.path.dirname(DB_PATH)
 
 def init_db():
     os.makedirs(DB_FOLDER, exist_ok=True)


### PR DESCRIPTION
## Summary
- allow override of database location via `INTAKE_DB_PATH`
- default `intake.db` to project directory
- ignore Python bytecode
- document database path override option

## Testing
- `python -m py_compile data/database.py gui/main_window.py gui/tabs/*.py main.py 'Gui w Regex V1.4.0.py'`

------
https://chatgpt.com/codex/tasks/task_e_68887cb19ff4832991cd09555ca68502