### PR TITLE
Fix database path to use project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ This tool opens in a new window and provides three tabs:
 2. Create a `.env` file with the environment variables used in
    `secrets.py` (for example `USERNAME` and `PASSWORD`).
 3. *(Optional)* Set `INTAKE_DB_PATH` in your environment to override the
-   default location of `intake.db`.
+   default database path. If not set, `intake.db` will be created in the
+   root of this project.
 
 4. Run the application:
 

--- a/data/database.py
+++ b/data/database.py
@@ -5,8 +5,13 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Determine the base directory of the repository. This ensures that the
+# default database path is always anchored to the project root rather than
+# the current working directory.
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_DB_PATH = os.path.join(BASE_DIR, "intake.db")
+
 # Allow overrides via environment variables
-DEFAULT_DB_PATH = os.path.join(os.getcwd(), "intake.db")
 DB_PATH = os.getenv("INTAKE_DB_PATH", DEFAULT_DB_PATH)
 DB_FOLDER = os.path.dirname(DB_PATH)
 


### PR DESCRIPTION
## Summary
- compute `DEFAULT_DB_PATH` relative to the repository instead of `os.getcwd`
- clarify in README that the DB defaults to `intake.db` in project root and can be overridden with `INTAKE_DB_PATH`

## Testing
- `python - <<'PY'
import subprocess, sys
import shlex, os
files = subprocess.check_output(['git','ls-files','*.py']).decode().splitlines()
for f in files:
    subprocess.check_call([sys.executable,'-m','py_compile',f])
print('All files compiled')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6889b9081a0c83299b012a085d231e79