### PR TITLE
Switch vendor lookup to vendor_names table

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -50,5 +50,10 @@ def init_db():
         metrc_vendor TEXT PRIMARY KEY,
         dutchie_vendor TEXT
     )""")
+    cur.execute("""
+    CREATE TABLE IF NOT EXISTS vendor_names (
+        metrc_vendor TEXT,
+        dutchie_vendor TEXT
+    )""")
     conn.commit()
     return conn

--- a/gui/tabs/vendor_names.py
+++ b/gui/tabs/vendor_names.py
@@ -56,7 +56,7 @@ class VendorNamesTab(QWidget):
         cur = self.conn.cursor()
         for r, (metrc, dutchie) in enumerate(
             cur.execute(
-                "SELECT metrc_vendor, dutchie_vendor FROM metrc_dutchie"
+                "SELECT metrc_vendor, dutchie_vendor FROM vendor_names"
             )
         ):
             self.vendorNameTable.insertRow(r)
@@ -96,12 +96,12 @@ class VendorNamesTab(QWidget):
     def save_vendor_names(self):
         """Write the current table contents back to the database."""
         cur = self.conn.cursor()
-        cur.execute("DELETE FROM metrc_dutchie")
+        cur.execute("DELETE FROM vendor_names")
         for r in range(self.vendorNameTable.rowCount()):
             metrc = self.vendorNameTable.item(r, 0).text()
             dutchie = self.vendorNameTable.item(r, 1).text()
             cur.execute(
-                "INSERT OR REPLACE INTO metrc_dutchie(metrc_vendor, dutchie_vendor) VALUES (?, ?)",
+                "INSERT OR REPLACE INTO vendor_names(metrc_vendor, dutchie_vendor) VALUES (?, ?)",
                 (metrc, dutchie),
             )
         self.conn.commit()

--- a/gui/tabs/vendor_products.py
+++ b/gui/tabs/vendor_products.py
@@ -57,7 +57,7 @@ class VendorProductsTab(QWidget):
         self.metrcVendorCombo.addItem("Select a Vendor")
         cur = self.conn.cursor()
         for metrc, dutchie in cur.execute(
-            "SELECT metrc_vendor, dutchie_vendor FROM metrc_dutchie"
+            "SELECT metrc_vendor, dutchie_vendor FROM vendor_names"
         ):
             self.vendor_map[metrc] = dutchie
             self.metrcVendorCombo.addItem(metrc)


### PR DESCRIPTION
## Summary
- create vendor_names table if it doesn't exist
- load vendor mappings from `vendor_names`
- write vendor mappings back to `vendor_names`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889c5ef28b483299d2fc5b79ee7379c