### PR TITLE
Connect manifest scraping to Active Manifest tab

### DIFF
--- a/automation/receive_inventory.py
+++ b/automation/receive_inventory.py
@@ -87,6 +87,8 @@ def scrape_receive_inventory():
         for item in items:
             print(f"  - {item}")
 
+    return results
+
 
 if __name__ == "__main__":
     scrape_receive_inventory()

--- a/gui/tabs/active_manifest.py
+++ b/gui/tabs/active_manifest.py
@@ -10,14 +10,17 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QTableWidget,
     QTableWidgetItem,
-    QHeaderView
+    QHeaderView,
+    QMessageBox,
 )
-from PyQt5.QtCore import QDate
+from PyQt5.QtCore import QDate, Qt
+from automation.receive_inventory import scrape_receive_inventory
 
 class ActiveManifestTab(QWidget):
     def __init__(self, conn):
         super().__init__()
         self.conn = conn
+        self.manifest_data = {}
         self._build_ui()
 
     def _build_ui(self):
@@ -51,6 +54,10 @@ class ActiveManifestTab(QWidget):
         btnLayout.addWidget(self.loadButton)
         layout.addLayout(btnLayout)
 
+        # Connect buttons
+        self.retrieveButton.clicked.connect(self.scrape_manifests)
+        self.loadButton.clicked.connect(self.load_manifest)
+
         # --- overview table ---
         self.overviewTable = QTableWidget(0, 11)
         self.overviewTable.setHorizontalHeaderLabels([
@@ -59,3 +66,51 @@ class ActiveManifestTab(QWidget):
         ])
         self.overviewTable.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         layout.addWidget(self.overviewTable)
+
+    def scrape_manifests(self):
+        """Retrieve manifests from Dutchie and populate the title combo."""
+        try:
+            data = scrape_receive_inventory()
+            if not isinstance(data, dict):
+                raise ValueError("No manifest data returned")
+            self.manifest_data = data
+            self.titleCombo.clear()
+            for title in data.keys():
+                self.titleCombo.addItem(title)
+        except Exception as exc:
+            QMessageBox.warning(self, "Scrape Error", str(exc))
+
+    def load_manifest(self):
+        """Load selected manifest items into the overview table."""
+        title = self.titleCombo.currentText()
+        if not title or title not in self.manifest_data:
+            QMessageBox.warning(self, "No Manifest", "Please scrape and select a manifest first.")
+            return
+
+        items = self.manifest_data[title]
+        self.overviewTable.setRowCount(0)
+
+        manifest = self.manifestInput.text().strip()
+        license_text = self.licenseInput.text().strip()
+        metrc_vendor = self.metrcVendorInput.currentText().strip()
+        received = self.dateInput.date().toString("yyyy-MM-dd")
+
+        for r, item in enumerate(items):
+            self.overviewTable.insertRow(r)
+            values = [
+                title,
+                manifest,
+                license_text,
+                metrc_vendor,
+                received,
+                item.get("name", ""),
+                item.get("quantity", ""),
+                item.get("cost", ""),
+                item.get("rec_price", ""),
+                "",
+                "",
+            ]
+            for c, val in enumerate(values):
+                itm = QTableWidgetItem(str(val))
+                itm.setTextAlignment(Qt.AlignCenter)
+                self.overviewTable.setItem(r, c, itm)


### PR DESCRIPTION
## Summary
- return scraped manifest data from `scrape_receive_inventory`
- hook new `scrape_manifests` button action in the Active Manifest tab
- fill the overview table with items from a selected manifest

## Testing
- `python -m py_compile automation/receive_inventory.py gui/tabs/active_manifest.py`

------
https://chatgpt.com/codex/tasks/task_e_688a50e56f1483299a2b8562bf101862