### PR TITLE
Fix quantity/rec keys in manifest

### DIFF
--- a/gui/tabs/active_manifest.py
+++ b/gui/tabs/active_manifest.py
@@ -104,9 +104,9 @@ class ActiveManifestTab(QWidget):
                 metrc_vendor,
                 received,
                 item.get("name", ""),
-                item.get("quantity", ""),
+                item.get("qty", ""),
                 item.get("cost", ""),
-                item.get("rec_price", ""),
+                item.get("rec", ""),
                 "",
                 "",
             ]


### PR DESCRIPTION
## Summary
- use `qty` and `rec` keys when loading scraped manifest data

## Testing
- `pytest -q`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_688a6bef4a2c8329af0089190baf6b8c